### PR TITLE
Fix plugin for flake8 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,13 @@ with open(os.path.join(__dir__, 'flake8_commas', '__about__.py')) as file:
     exec(file.read(), about)
 
 
+def get_error_code():
+    with open(os.path.join(__dir__, 'flake8_commas', '__init__.py')) as file:
+        for line in file:
+            if line.startswith('COMMA_ERROR_CODE = '):
+                return eval(line.split(' = ', 1)[-1])
+
+
 setup(
     name='flake8-commas',
     author='Trevor Creech',
@@ -37,7 +44,7 @@ setup(
     include_package_data=True,
     entry_points={
         'flake8.extension': [
-            'flake8_commas = flake8_commas:CommaChecker',
+            '%s = flake8_commas:CommaChecker' % get_error_code(),
         ],
     },
     classifiers=[


### PR DESCRIPTION
This fixes the extension for `flake8>=3`, issue #20. I just followed the convention in the documentation: http://flake8.readthedocs.io/en/latest/plugin-development/registering-plugins.html

Tried it with both flake8 2.6.2 & 3.0.4 - works in both.
