### PR TITLE
Fix list-item-comment Fixes #18

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- If there is a comment after the last item, do not report an error
+  (`Issue #18 <https://github.com/flake8-commas/flake8-commas/pull/18>`_)
 
 
 0.2.0 (2017-01-13)

--- a/test/data/bad_list.py
+++ b/test/data/bad_list.py
@@ -3,3 +3,19 @@ bad_list = [
     2,
     3
 ]
+
+bad_list_with_comment = [
+    1,
+    2,
+    3
+    # still needs a comma!
+]
+
+bad_list_with_extra_empty = [
+    1,
+    2,
+    3
+
+
+
+]

--- a/test/data/good_list.py
+++ b/test/data/good_list.py
@@ -1,0 +1,13 @@
+stuff = [
+   'a',
+   'b',
+   # more stuff will go here
+]
+
+more_stuff = [
+    'a',
+    'b',
+
+
+
+]

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -28,6 +28,8 @@ class CommaTestChecks(TestCase):
         comma_checker = CommaChecker(None, filename=get_absolute_path('data/bad_list.py'))
         self.assertEqual(list(comma_checker.get_comma_errors(comma_checker.get_file_contents())), [
             {'col': 5, 'line': 4, 'message': 'C812 missing trailing comma'},
+            {'col': 5, 'line': 10, 'message': 'C812 missing trailing comma'},
+            {'col': 5, 'line': 17, 'message': 'C812 missing trailing comma'},
         ])
 
     def test_bad_function_call(self):
@@ -98,6 +100,11 @@ class CommaTestChecks(TestCase):
 
     def test_comma_not_required_in_parenth_form_string_splits(self):
         fixture = 'data/multiline_string.py'
+        comma_checker = CommaChecker(None, filename=get_absolute_path(fixture))
+        self.assertEqual(list(comma_checker.get_comma_errors(comma_checker.get_file_contents())), [])
+
+    def test_comma_not_required_in_comment_lines(self):
+        fixture = 'data/good_list.py'
         comma_checker = CommaChecker(None, filename=get_absolute_path(fixture))
         self.assertEqual(list(comma_checker.get_comma_errors(comma_checker.get_file_contents())), [])
 


### PR DESCRIPTION
Fix cases where adding a comment or multiple new lines prevents
new lines being required in the correct location, and requiring them
after the end of the comment.