### PR TITLE
initialised token

### DIFF
--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -248,7 +248,7 @@ class CommaChecker(object):
     def __init__(self, tree, filename='(none)', file_tokens=None):
         fn = 'stdin' if filename in ('stdin', '-', None) else filename
         self.filename = fn
-        self.tokens = file_tokens
+        self.tokens = [Token(t) for t in file_tokens] if file_tokens else None
 
     def run(self):
         tokens = self.tokens


### PR DESCRIPTION
tokens are not fed into the `Token` class when they are passed as `file_tokens` parameter in the `CommaChecker` class. 
Any check to the `Token` class properties will create an error. This PR fixes these errors.