### PR TITLE
Don't require comma after assert expression enclosed in brackets

### DIFF
--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -39,7 +39,7 @@ PYTHON_3_KWDS = {
     'or', 'pass', 'raise', 'return', 'try', 'while', 'with', 'yield',
 }
 
-KWD_LIKE_FUNCTION = {'import', 'assert'}
+KWD_LIKE_FUNCTION = {'import'}
 
 ALL_KWDS = (PYTHON_2_KWDS & PYTHON_3_KWDS) - KWD_LIKE_FUNCTION
 NOT_PYTHON_2_KWDS = (PYTHON_3_KWDS - PYTHON_2_KWDS) - KWD_LIKE_FUNCTION
@@ -82,6 +82,7 @@ DEF = 'def'
 FUNCTION_DEF = 'function-def'
 FUNCTION = {NAMED, PY2_ONLY_ERROR, PY3K_ONLY_ERROR, FUNCTION_DEF}
 UNPACK = '* or **'
+ASSERT = 'assert'
 NONE = SimpleToken(token=None, type=None)
 
 
@@ -95,6 +96,8 @@ def get_type(token):
         return FOR
     if type == tokenize.NAME and string == 'def':
         return DEF
+    if type == tokenize.NAME and string == 'assert':
+        return ASSERT
     if type == mod_token.NAME and string not in ALL_KWDS:
         if string in NOT_PYTHON_2_KWDS:
             return PY2_ONLY_ERROR

--- a/test/data/keyword_before_parenth_form/base.py
+++ b/test/data/keyword_before_parenth_form/base.py
@@ -8,6 +8,15 @@ assert(
     Anyway,
 )
 
+assert (
+    foo
+)
+
+assert (
+    foo and
+    bar
+)
+
 if(
     foo and
     bar


### PR DESCRIPTION
Fixes

```python
assert (
    True  # C812 missing trailing comma
)

assert (
    True and
    False  # C812 missing trailing comma
)
```

The actual fix seems really simple (unless I'm missing something): just remove it from `KWD_LIKE_FUNCTION`. But that turns the token into `named`  which seems be wrong. Probably it makes sense in addition to that to special-case `assert` because it should never be followed by a parenthesized form with commas. Meaning, flake8-commas should not care about `assert` at all when doing the checks.