### PR TITLE
Allow bare wrapped index access

### DIFF
--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -167,10 +167,14 @@ def process_parentheses(token, prev_1, prev_2):
             return [Context(TUPLE_OR_PARENTH_FORM, False)]
 
     if token.type == OPENING_SQUARE_BRACKET:
-        is_index_access = previous_token and
-        (
-            previous_token.type in CLOSING or
-            previous_token.type == NAMED
+        is_index_access = (
+            previous_token and
+            (
+                (previous_token.type in CLOSING) or
+                (
+                    previous_token.type == NAMED
+                )
+            )
         )
         if is_index_access:
             return [Context(False, False)]

--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -68,9 +68,10 @@ Context = collections.namedtuple('Context', ['comma', 'unpack'])
 NEW_LINE = 'new-line'
 COMMA = ','
 OPENING_BRACKET = '('
+OPENING_SQUARE_BRACKET = '['
 SOME_CLOSING = 'some-closing'
 SOME_OPENING = 'some-opening'
-OPENING = {SOME_OPENING,  OPENING_BRACKET}
+OPENING = {SOME_OPENING,  OPENING_BRACKET, OPENING_SQUARE_BRACKET}
 CLOSING = {SOME_CLOSING}
 BACK_TICK = '`'
 CLOSE_ATOM = CLOSING | {BACK_TICK}
@@ -107,6 +108,8 @@ def get_type(token):
         return COMMA
     if string == '(':
         return OPENING_BRACKET
+    if string == '[':
+        return OPENING_SQUARE_BRACKET
     if string in {'[', '{'}:
         return SOME_OPENING
     if string in {']', ')', '}'}:
@@ -162,6 +165,15 @@ def process_parentheses(token, prev_1, prev_2):
                 return [Context(PY3K_ONLY_ERROR, False)]
         else:
             return [Context(TUPLE_OR_PARENTH_FORM, False)]
+
+    if token.type == OPENING_SQUARE_BRACKET:
+        is_index_access = previous_token and
+        (
+            previous_token.type in CLOSING or
+            previous_token.type == NAMED
+        )
+        if is_index_access:
+            return [Context(False, False)]
 
     return [Context(True, False)]
 

--- a/test/data/multiline_index_access.py
+++ b/test/data/multiline_index_access.py
@@ -2,6 +2,14 @@ multiline_index_access[
     "good"
 ]
 
+multiline_index_access_after_function()[
+    "good"
+]
+
+multiline_index_access_after_inline_index_access['first'][
+    "good"
+]
+
 multiline_index_access[
     "probably fine",
 ]

--- a/test/data/multiline_index_access.py
+++ b/test/data/multiline_index_access.py
@@ -1,0 +1,7 @@
+multiline_index_access[
+    "good"
+]
+
+multiline_index_access[
+    "probably fine",
+]

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -95,6 +95,12 @@ def test_no_comma_required_multiline_if():
     assert list(get_comma_errors(get_tokens(filename))) == []
 
 
+def test_no_comma_required_multiline_index_access():
+    fixture = 'data/multiline_index_access.py'
+    filename = get_absolute_path(fixture)
+    assert list(get_comma_errors(get_tokens(filename))) == []
+
+
 def test_comma_required_after_unpack_in_non_def_python_3_5():
     fixture = 'data/unpack.py'
     filename = get_absolute_path(fixture)


### PR DESCRIPTION
This resolves an issue where `flake8-commas` incorrectly requires a trailing comma in a multiline index access, such as:
``` python
foo = {}
bar = foo[
    'a-really-long-key-name'
]
```

In such cases adding a comma changes the key into a 1-tuple around the given value, which is semantically different.