### PR TITLE
add rule for prohibited trailing commas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Remove EOL Python 3.3.
   (`Issue #47 <https://github.com/flake8-commas/flake8-commas/pull/47>`_)
+- Prohibit trailing commas where there is no following new line
+  (or forming a single element tuple).
+  (`Issue #46 <https://github.com/flake8-commas/flake8-commas/pull/46>`_)
 
 
 0.4.3 (2017-04-25)

--- a/README.rst
+++ b/README.rst
@@ -31,3 +31,5 @@ errors for languages you don't use in your flake8 config:
 +------+---------------------------------------+
 | C816 | missing trailing comma in Python 3.6+ |
 +------+---------------------------------------+
+| C819 | trailing comma prohibited             |
++------+---------------------------------------+

--- a/test/data/prohibited.py
+++ b/test/data/prohibited.py
@@ -1,0 +1,21 @@
+foo = ['a', 'b', 'c',]
+
+bar = { a: b,}
+
+def bah(ham, spam,):
+    pass
+
+(0,)
+
+(0, 1,)
+
+foo = ['a', 'b', 'c', ]
+
+bar = { a: b, }
+
+def bah(ham, spam, ):
+    pass
+
+(0, )
+
+(0, 1, )

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -229,5 +229,19 @@ def test_py3():
     assert list(get_comma_errors(get_tokens(filename))) == []
 
 
+def test_prohibited():
+    filename = get_absolute_path('data/prohibited.py')
+    assert list(get_comma_errors(get_tokens(filename))) == [
+       {'col': 21, 'line': 1, 'message': 'C819 trailing comma prohibited'},
+       {'col': 13, 'line': 3, 'message': 'C819 trailing comma prohibited'},
+       {'col': 18, 'line': 5, 'message': 'C819 trailing comma prohibited'},
+       {'col': 6, 'line': 10, 'message': 'C819 trailing comma prohibited'},
+       {'col': 21, 'line': 12, 'message': 'C819 trailing comma prohibited'},
+       {'col': 13, 'line': 14, 'message': 'C819 trailing comma prohibited'},
+       {'col': 18, 'line': 16, 'message': 'C819 trailing comma prohibited'},
+       {'col': 6, 'line': 21, 'message': 'C819 trailing comma prohibited'},
+    ]
+
+
 def get_absolute_path(filepath):
     return os.path.join(os.path.dirname(__file__), filepath)


### PR DESCRIPTION
to stop crazy stuff like:

```python
foo = ['a', 'b', 'c',]

def bah(ham, spam,):
    pass
```